### PR TITLE
Allow overwriting $SUPW by an environment variable

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 chown -R mumble: /var/lib/mumble-server
 
 touch /var/lib/mumble-server

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,10 @@ chown -R mumble: /var/lib/mumble-server
 
 touch /var/lib/mumble-server
 
-SUPW=`pwgen -c -n -1 15`
+
+if [ -z "$SUPW" ]; then
+    SUPW=`pwgen -c -n -1 15`
+fi
 
 echo "Superuser Password: $SUPW"
 

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ touch /var/lib/mumble-server
 
 
 if [ -z "$SUPW" ]; then
-    SUPW=`pwgen -c -n -1 15`
+    SUPW="$(pwgen -c -n -1 15)"
 fi
 
 echo "Superuser Password: $SUPW"
@@ -13,10 +13,10 @@ echo "Superuser Password: $SUPW"
 #exec sumurmurd -ini /etc/mumble-server.ini -supw $SUPW
 #exec sudo -u mumble murmurd -ini /etc/mumble-server.ini -fg
 
-/usr/sbin/murmurd -supw $SUPW
+/usr/sbin/murmurd -supw "$SUPW"
 /usr/sbin/murmurd -fg
 
 #/usr/bin/murmurd -ini /etc/mumble-server.ini -fg
-#murmurd -ini /etc/mumble-server.ini -supw $SUPW -fg
-#/usr/sbin/murmurd -fg -supw $SUPW
+#murmurd -ini /etc/mumble-server.ini -supw "$SUPW" -fg
+#/usr/sbin/murmurd -fg -supw "$SUPW"
 

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ touch /var/lib/mumble-server
 
 
 if [ -z "$SUPW" ]; then
-    SUPW="$(pwgen -c -n -1 15)"
+    SUPW="$(pwgen -s -c -n -1 15)"
 fi
 
 echo "Superuser Password: $SUPW"


### PR DESCRIPTION
Thought this might be useful for the hashbang team as well: this change allows you to overwrite the generated SUPW by one provided as an environment variable, this is handy if your instances tend to rotate and you'd like to keep the password predictable.
